### PR TITLE
Change 'Infinity' to 0x7FFFFFFF

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ var that = module.exports = {
 		};
 		this.clients.push(_o);
 
-		req.socket.setTimeout(Infinity);
+		req.socket.setTimeout(0x7FFFFFFF);
 
 		req.connection.addListener("close", function() {
 			that.remove(_id);


### PR DESCRIPTION
req.socket.setTimeout(Infinity) is breaking on Node v0.12.
